### PR TITLE
Define __ne__ for ApproximateDate, and some tidying up

### DIFF
--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -59,7 +59,10 @@ class ApproximateDate(object):
             return False
         else:
             return True
-        
+
+    def __ne__(self, other):
+        return not (self == other)
+
     def __lt__(self, other):
         if other is None:
             return False

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -12,6 +12,7 @@ class CompareDates(unittest.TestCase):
         y_past     = ApproximateDate( year=2000 )
         y_future   = ApproximateDate( year=2100 )
         future     = ApproximateDate( future=True )
+        future_too = ApproximateDate( future=True )
 
         # check that we can be compared to None, '' and u''
         for bad_val in ( '', u'', None ):
@@ -51,12 +52,13 @@ class CompareDates(unittest.TestCase):
         self.assertTrue( future >= y_future )
 
         # Future dates are equal to themselves (so that sorting is sane)
-        self.assertFalse( future <  future )
-        self.assertTrue(  future <= future )
-        self.assertTrue(  future == future )
-        self.assertTrue(  future >= future )
-        self.assertFalse( future >  future )
-
+        self.assertFalse( future <  future     )
+        self.assertTrue(  future <= future     )
+        self.assertTrue(  future == future     )
+        self.assertTrue(  future >= future     )
+        self.assertFalse( future >  future     )
+        self.assertTrue(  future == future_too )
+        self.assertFalse( future != future_too )
 
 class Lengths(unittest.TestCase):
     known_lengths = (


### PR DESCRIPTION
!= comparisons between ApproximateDate objects were broken, unfortunately. One of these commits fixes that and the other removes some unnecessary trailing semi-colons from the tests.
