### PR TITLE
adding support for filtering by python date or datetime

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.pyc
 .venv
+.idea
 /MANIFEST
 /dist
 atlassian-ide-plugin.xml

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -174,12 +174,13 @@ class ApproximateDateField(with_metaclass(models.SubfieldBase, models.CharField)
         if value == 'past':
             return 'past'
             
-        ansi_match = ansi_date_re.search(value)
-        prefix_match = prefix_date_re.search(value)
-        if not ansi_match and not prefix_match:
+        prefix_date = prefix_date_re.search(value)
+        prefix_date_reverse = prefix_date_reverse_re.search(value)
+        ansi_date = ansi_date_re.search(value)
+        if not prefix_date and not prefix_date_reverse and not ansi_date:
             raise ValidationError('Enter a valid date in YYYY-MM-DD format.')
-        if prefix_match:
-            value = '{0} {1}'.format(prefix_match.group(2), prefix_match.group(1))
+        if prefix_date_reverse:
+            value = '{0} {1}'.format(prefix_date_reverse.group(2), prefix_date_reverse.group(1))
         return value
 
     def value_to_string(self, obj):

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -3,7 +3,7 @@ import time
 import re
 from functools import total_ordering
 
-from six import with_metaclass
+from django.utils.six import with_metaclass
 from django.db import models
 from django import forms
 from django.forms import ValidationError

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -75,7 +75,7 @@ class ApproximateDate(object):
         elif self.year and self.month:
             return dateformat.format(self, settings.OUTPUT_FORMAT_MONTH_YEAR)
         elif self.year and self.prefix:
-            return '{0}-{1}'.format(self.prefix, dateformat.format(self, settings.OUTPUT_FORMAT_YEAR))
+            return '{0} {1}'.format(self.prefix, dateformat.format(self, settings.OUTPUT_FORMAT_YEAR))
         elif self.year:
             return dateformat.format(self, settings.OUTPUT_FORMAT_YEAR)
 
@@ -110,7 +110,7 @@ class ApproximateDate(object):
 
 
 ansi_date_re = re.compile(r'^\d{4}-\d{1,2}-\d{1,2}$')
-prefix_date_re = re.compile(r'^([a-zA-Z]+)-(\d{4})$')
+prefix_date_re = re.compile(r'^([a-zA-Z]+) (\d{4})$')
 
 
 class ApproximateDateField(with_metaclass(models.SubfieldBase, models.CharField)):
@@ -143,7 +143,7 @@ class ApproximateDateField(with_metaclass(models.SubfieldBase, models.CharField)
                 raise ValidationError('Enter a valid date in YYYY-MM-DD format.')
 
             if prefix_date:
-                prefix, year = value.split('-')
+                prefix, year = value.split(' ')
                 year, month, day = map(int, [year, 0, 0])
             else:
                 year, month, day = map(int, value.split('-'))
@@ -212,7 +212,7 @@ class ApproximateDateFormField(forms.fields.Field):
                 continue
 
         prefix = None
-        match = prefix_date_re.search(value.replace(' ', '-'))
+        match = prefix_date_re.search(value)
         if match:
             prefix = match.group(1)
             value = match.group(2)

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -212,7 +212,7 @@ class ApproximateDateFormField(forms.fields.Field):
                 continue
 
         prefix = None
-        match = prefix_date_re.search(value)
+        match = prefix_date_re.search(value.replace(' ', '-'))
         if match:
             prefix = match.group(1)
             value = match.group(2)

--- a/django_date_extensions/settings.py
+++ b/django_date_extensions/settings.py
@@ -31,3 +31,5 @@ DAY_MONTH_INPUT_FORMATS = getattr(settings, 'DATE_EXTENSIONS_DAY_MONTH_INPUT_FOR
     '%b %d', '%d %b',  # 'Oct 25', '25 Oct'
     '%B %d', '%d %B',  # 'October 25', '25 October'
 ))
+
+ALLOWED_PREFIX = [p.lower() for p in getattr(settings, 'DATE_EXTENSIONS_ALLOWED_PREFIX', [])]

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -4,8 +4,9 @@ os.environ['DJANGO_SETTINGS_MODULE'] = 'example.settings'
 import unittest
 
 from django.db import models
+from django import forms
 
-from .fields import ApproximateDate, ApproximateDateField
+from .fields import ApproximateDate, ApproximateDateField, ApproximateDateFormField
 from . import settings
 
 settings.ALLOWED_PREFIX = ['about', 'abouts']
@@ -16,6 +17,10 @@ class ApproxDateModel(models.Model):
 
     def __unicode__(self):
         return u'%s' % str(self.start)
+
+
+class ApproxDateForm(forms.Form):
+    start = ApproximateDateFormField()
 
 
 class PastAndFuture(unittest.TestCase):
@@ -207,6 +212,12 @@ class PrefixDates(unittest.TestCase):
 
     def test_not_allowed_prefix(self):
         self.assertRaises(ValueError, ApproximateDate, prefix='what', year=2015)
+
+    def test_date_with_prefix_form(self):
+        form = ApproxDateForm({'start': 'about 2015'})
+        self.assertTrue(form.is_valid())
+        form = ApproxDateForm({'start': '2015'})
+        self.assertTrue(form.is_valid())
 
 
 if __name__ == "__main__":

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -199,7 +199,7 @@ class PrefixDates(unittest.TestCase):
         self.assertRaises(ValueError, ApproximateDate, prefix='about', year=2015, month=12)
 
     def test_stringification(self):
-        self.assertEqual(str(ApproximateDate(year=2010, prefix='about')), 'about-2010')
+        self.assertEqual(str(ApproximateDate(year=2010, prefix='about')), 'about 2010')
         self.assertEqual(str(ApproximateDate(year=2010)), '2010')
 
     def test_db(self):

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -1,9 +1,18 @@
-from datetime import date
+from datetime import date, datetime
 import os
 os.environ['DJANGO_SETTINGS_MODULE'] = 'example.settings'
 import unittest
 
-from .fields import ApproximateDate
+from django.db import models
+
+from .fields import ApproximateDate, ApproximateDateField
+
+
+class ApproxDateModel(models.Model):
+    start = ApproximateDateField()
+
+    def __unicode__(self):
+        return u'%s' % str(self.start)
 
 
 class PastAndFuture(unittest.TestCase):
@@ -139,6 +148,24 @@ class Lengths(unittest.TestCase):
         for kwargs, length in self.known_lengths:
             approx = ApproximateDate(**kwargs)
             self.assertEqual(len(approx), length)
+
+
+class ApproxDateFiltering(unittest.TestCase):
+
+    def setUp(self):
+        for year in [2000, 2001, 2002, 2003, 2004]:
+            ApproxDateModel.objects.create(start=ApproximateDate(year=year))
+
+    def test_filtering_with_python_date(self):
+        qs = ApproxDateModel.objects.filter(start__gt=date.today())
+        # force evaluate queryset
+        list(qs)
+
+    def test_filtering_with_python_datetime(self):
+        qs = ApproxDateModel.objects.filter(start__gt=datetime.now())
+        # force evaluate queryset
+        list(qs)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -218,7 +218,15 @@ class PrefixDates(unittest.TestCase):
         self.assertTrue(form.is_valid())
         form = ApproxDateForm({'start': '2015'})
         self.assertTrue(form.is_valid())
-
+    
+    def test_ordering(self):
+        ApproxDateModel.objects.all().delete()
+        years = [2015, 2006, 2013, 2004, 2003, 1989]
+        for year in years:
+            ApproxDateModel.objects.create(start=ApproximateDate(year=year, prefix='about'))
+        self.assertEqual(sorted(years), [o.start.year for o in ApproxDateModel.objects.all().order_by('start')])
+        self.assertEqual(sorted(years, reverse=True), [o.start.year for o in ApproxDateModel.objects.all().order_by('-start')])
+        
 
 if __name__ == "__main__":
     unittest.main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [flake8]
 max-line-length=119
+
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django_date_extensions',
-    version='1.1.0',
+    version='1.1.1',
     url='https://github.com/dracos/django-date-extensions',
     packages=['django_date_extensions',],
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django_date_extensions',
-    version='1.1.1',
+    version='1.1.2',
     url='https://github.com/dracos/django-date-extensions',
     packages=['django_date_extensions',],
     license='BSD',

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,23 @@
-from distutils.core import setup
+from setuptools import setup
 
 setup(
     name='django_date_extensions',
-    version='1.0.0',
+    version='1.1.0',
     url='https://github.com/dracos/django-date-extensions',
     packages=['django_date_extensions',],
-    license='GNU Affero General Public license',
+    license='BSD',
     description="This code adds a few small extensions to Django's DateField, to handle both approximate dates (e.g. 'March 1963') and default year dates (e.g. assume '24th June' is the most recent such).",
     long_description=open('README.txt').read(),
     author='Matthew Somerville',
     author_email='matthew-pypi@dracos.co.uk',
     requires=[
         'Django',
-        'six',
     ],
     classifiers=[
         'Development Status :: 5 - Production/Stable',
         'Environment :: Web Environment',
         'Framework :: Django',
-        'License :: OSI Approved :: GNU Affero General Public License v3',
+        'License :: OSI Approved :: BSD License',
         'Intended Audience :: Developers',
         'Programming Language :: Python :: 2.7',
         'Programming Language :: Python :: 3.3',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name='django_date_extensions',
-    version='1.1.2',
+    version='1.1.3',
     url='https://github.com/dracos/django-date-extensions',
     packages=['django_date_extensions',],
     license='BSD',


### PR DESCRIPTION
This pull request allows user to filter the `ApproximateDateField` with Python `datetime.date` or `datetime.datetime`. Added some basic test for filtering which just only checks if the filtering was successful.