### PR TITLE
String formats

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 /build
 /django_date_extensions.egg-info/
 /.tox
+/venv
+# pyCharm
+.idea

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -152,6 +152,9 @@ class ApproximateDateField(FIELD_BASE):
         if isinstance(value, (datetime.date, datetime.datetime)):
             year, month, day = value.year, value.month, value.day
         else:
+            if value in settings.STRING_FORMATS:
+                return ApproximateDate(string_format=value)
+
             prefix_date = prefix_date_re.search(value)
             prefix_date_reverse = prefix_date_reverse_re.search(value)
             ansi_date = ansi_date_re.search(value)

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -26,8 +26,13 @@ PREFIX_RE = re.compile('^(?i)[a-zA-Z]+[.,]?$')
 class ApproximateDate(object):
     """A date object that accepts 0 for month or day to mean we don't
        know when it is within that month/year."""
-    def __init__(self, year=0, month=0, day=0, future=False, past=False, prefix=None):
-        if future and past:
+    def __init__(self, year=0, month=0, day=0, future=False, past=False, prefix=None, string_format=None):
+        if string_format:
+            if year or month or day or future or past or prefix:
+                raise ValueError("String format can have no year, month, day, prefix, future or past")
+            elif string_format.lower() not in settings.STRING_FORMATS:
+                raise ValueError("Invalid string format `{0}`".format(string_format))
+        elif future and past:
             raise ValueError("Can't be both future and past")
         elif future or past:
             if year or month or day or prefix:
@@ -47,7 +52,7 @@ class ApproximateDate(object):
         if prefix:
             if not settings.ALLOWED_PREFIX:
                 raise ValueError("Prefix not allowed")
-            elif month or day:
+            elif month or day or string_format:
                 raise ValueError("Prefix can only be set with Year only date")
             elif not PREFIX_RE.match(prefix):
                 raise ValueError("Prefix value can only contains alphabets and can have maximum of 5 characters")
@@ -60,9 +65,10 @@ class ApproximateDate(object):
         self.month = month
         self.day = day
         self.prefix = prefix
+        self.string_format = string_format
 
     def __repr__(self):
-        if self.future or self.past or self.prefix:
+        if self.future or self.past or self.prefix or self.string_format:
             return str(self)
         return "{year:04d}-{month:02d}-{day:02d}".format(year=self.year, month=self.month, day=self.day)
 
@@ -71,6 +77,8 @@ class ApproximateDate(object):
             return 'future'
         elif self.past:
             return 'past'
+        elif self.string_format:
+            return self.string_format
         elif self.year and self.month and self.day:
             return dateformat.format(self, settings.OUTPUT_FORMAT_DAY_MONTH_YEAR)
         elif self.year and self.month:
@@ -88,8 +96,8 @@ class ApproximateDate(object):
         if not isinstance(other, ApproximateDate):
             return False
 
-        return (self.year, self.month, self.day, self.future, self.past, self.prefix) ==\
-               (other.year, other.month, other.day, other.future, other.past, other.prefix)
+        return (self.year, self.month, self.day, self.future, self.past, self.prefix, self.string_format) ==\
+               (other.year, other.month, other.day, other.future, other.past, other.prefix, self.string_format)
 
     def __ne__(self, other):
         return not (self == other)
@@ -183,6 +191,9 @@ class ApproximateDateField(FIELD_BASE):
         if value == 'past':
             return 'past'
 
+        if value.lower() in settings.STRING_FORMATS:
+            return value
+
         prefix_date = prefix_date_re.search(value)
         prefix_date_reverse = prefix_date_reverse_re.search(value)
         ansi_date = ansi_date_re.search(value)
@@ -244,6 +255,10 @@ class ApproximateDateFormField(forms.fields.Field):
                 return ApproximateDate(time.strptime(value, year_format)[0], 0, 0, prefix=prefix)
             except ValueError:
                 continue
+
+        if value.lower() in settings.STRING_FORMATS:
+            return ApproximateDate(string_format=value)
+
         raise ValidationError('Please enter a valid date.')
 
 

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -3,6 +3,7 @@ import time
 import re
 from functools import total_ordering
 
+from django.utils.six import with_metaclass
 from django.db import models
 from django import forms
 from django.forms import ValidationError
@@ -17,17 +18,19 @@ try:
 except ImportError:
     pass
 
+PREFIX_RE = re.compile('^(?i)[a-zA-Z]+[.,]?$')
+
 
 @total_ordering
 class ApproximateDate(object):
     """A date object that accepts 0 for month or day to mean we don't
        know when it is within that month/year."""
-    def __init__(self, year=0, month=0, day=0, future=False, past=False):
+    def __init__(self, year=0, month=0, day=0, future=False, past=False, prefix=None):
         if future and past:
             raise ValueError("Can't be both future and past")
         elif future or past:
-            if year or month or day:
-                raise ValueError("Future or past dates can have no year, month or day")
+            if year or month or day or prefix:
+                raise ValueError("Future or past dates can have no year, month, day or prefix")
         elif year and month and day:
             datetime.date(year, month, day)
         elif year and month:
@@ -39,26 +42,40 @@ class ApproximateDate(object):
         else:
             raise ValueError("You must specify a year")
 
+        # validate prefix
+        if prefix:
+            if not settings.ALLOWED_PREFIX:
+                raise ValueError("Prefix not allowed")
+            elif month or day:
+                raise ValueError("Prefix can only be set with Year only date")
+            elif not PREFIX_RE.match(prefix):
+                raise ValueError("Prefix value can only contains alphabets and can have maximum of 5 characters")
+            elif prefix.lower() not in settings.ALLOWED_PREFIX:
+                raise ValueError("Prefix '{0}' not allowed".format(prefix))
+
         self.future = future
         self.past = past
         self.year = year
         self.month = month
         self.day = day
+        self.prefix = prefix
 
     def __repr__(self):
-        if self.future or self.past:
+        if self.future or self.past or self.prefix:
             return str(self)
         return "{year:04d}-{month:02d}-{day:02d}".format(year=self.year, month=self.month, day=self.day)
 
     def __str__(self):
         if self.future:
             return 'future'
-        if self.past:
+        elif self.past:
             return 'past'
         elif self.year and self.month and self.day:
             return dateformat.format(self, settings.OUTPUT_FORMAT_DAY_MONTH_YEAR)
         elif self.year and self.month:
             return dateformat.format(self, settings.OUTPUT_FORMAT_MONTH_YEAR)
+        elif self.year and self.prefix:
+            return '{0} {1}'.format(self.prefix, dateformat.format(self, settings.OUTPUT_FORMAT_YEAR))
         elif self.year:
             return dateformat.format(self, settings.OUTPUT_FORMAT_YEAR)
 
@@ -70,8 +87,8 @@ class ApproximateDate(object):
         if not isinstance(other, ApproximateDate):
             return False
 
-        return (self.year, self.month, self.day, self.future, self.past) ==\
-               (other.year, other.month, other.day, other.future, other.past)
+        return (self.year, self.month, self.day, self.future, self.past, self.prefix) ==\
+               (other.year, other.month, other.day, other.future, other.past, other.prefix)
 
     def __ne__(self, other):
         return not (self == other)
@@ -93,9 +110,16 @@ class ApproximateDate(object):
 
 
 ansi_date_re = re.compile(r'^\d{4}-\d{1,2}-\d{1,2}$')
+prefix_date_re = re.compile(r'^([a-zA-Z]+[.,]?) (\d{4})$')
+prefix_date_reverse_re = re.compile(r'^(\d{4}) ([a-zA-Z]+[,.]?)$')
+
+try:
+    FIELD_BASE = with_metaclass(models.SubfieldBase, models.CharField)
+except AttributeError:
+    FIELD_BASE = models.CharField
 
 
-class ApproximateDateField(models.CharField):
+class ApproximateDateField(FIELD_BASE):
     """A model field to store ApproximateDate objects in the database
        (as a CharField because MySQLdb intercepts dates from the
        database and forces them to be datetime.date()s."""
@@ -114,12 +138,28 @@ class ApproximateDateField(models.CharField):
         if value == 'past':
             return ApproximateDate(past=True)
 
-        if not ansi_date_re.search(value):
-            raise ValidationError('Enter a valid date in YYYY-MM-DD format.')
+        prefix = None
 
-        year, month, day = map(int, value.split('-'))
+        if isinstance(value, (datetime.date, datetime.datetime)):
+            year, month, day = value.year, value.month, value.day
+        else:
+            prefix_date = prefix_date_re.search(value)
+            prefix_date_reverse = prefix_date_reverse_re.search(value)
+            ansi_date = ansi_date_re.search(value)
+            if not prefix_date and not ansi_date and not prefix_date_reverse:
+                raise ValidationError('Enter a valid date in YYYY-MM-DD format.')
+
+            if prefix_date:
+                prefix, year = value.split(' ')
+                year, month, day = map(int, [year, 0, 0])
+            elif prefix_date_reverse:
+                year, prefix = value.split(' ')
+                year, month, day = map(int, [year, 0, 0])
+            else:
+                year, month, day = map(int, value.split('-'))
+
         try:
-            return ApproximateDate(year, month, day)
+            return ApproximateDate(year, month, day, prefix=prefix)
         except ValueError as e:
             msg = 'Invalid date: %s' % str(e)
             raise ValidationError(msg)
@@ -132,15 +172,23 @@ class ApproximateDateField(models.CharField):
         if value in (None, ''):
             return ''
         if isinstance(value, ApproximateDate):
+            if value.prefix:
+                return '{0} {1}'.format(value.year, value.prefix)
             return repr(value)
-        if isinstance(value, datetime.date):
+        if isinstance(value, (datetime.date, datetime.datetime)):
             return dateformat.format(value, "Y-m-d")
         if value == 'future':
             return 'future'
         if value == 'past':
             return 'past'
-        if not ansi_date_re.search(value):
+
+        prefix_date = prefix_date_re.search(value)
+        prefix_date_reverse = prefix_date_reverse_re.search(value)
+        ansi_date = ansi_date_re.search(value)
+        if not prefix_date and not prefix_date_reverse and not ansi_date:
             raise ValidationError('Enter a valid date in YYYY-MM-DD format.')
+        if prefix_date_reverse:
+            value = '{0} {1}'.format(prefix_date_reverse.group(2), prefix_date_reverse.group(1))
         return value
 
     def value_to_string(self, obj):
@@ -172,20 +220,27 @@ class ApproximateDateFormField(forms.fields.Field):
         if isinstance(value, ApproximateDate):
             return value
         value = re.sub('(?<=\d)(st|nd|rd|th)', '', value.strip())
-        for format in settings.DATE_INPUT_FORMATS:
+        for date_format in settings.DATE_INPUT_FORMATS:
             try:
-                return ApproximateDate(*time.strptime(value, format)[:3])
+                return ApproximateDate(*time.strptime(value, date_format)[:3])
             except ValueError:
                 continue
-        for format in settings.MONTH_INPUT_FORMATS:
+        for month_format in settings.MONTH_INPUT_FORMATS:
             try:
-                match = time.strptime(value, format)
+                match = time.strptime(value, month_format)
                 return ApproximateDate(match[0], match[1], 0)
             except ValueError:
                 continue
-        for format in settings.YEAR_INPUT_FORMATS:
+
+        prefix = None
+        match = prefix_date_re.search(value)
+        if match:
+            prefix = match.group(1)
+            value = match.group(2)
+
+        for year_format in settings.YEAR_INPUT_FORMATS:
             try:
-                return ApproximateDate(time.strptime(value, format)[0], 0, 0)
+                return ApproximateDate(time.strptime(value, year_format)[0], 0, 0, prefix=prefix)
             except ValueError:
                 continue
         raise ValidationError('Please enter a valid date.')

--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -3,6 +3,7 @@ import time
 import re
 from functools import total_ordering
 
+import django
 from django.utils.six import with_metaclass
 from django.db import models
 from django import forms
@@ -113,9 +114,9 @@ ansi_date_re = re.compile(r'^\d{4}-\d{1,2}-\d{1,2}$')
 prefix_date_re = re.compile(r'^([a-zA-Z]+[.,]?) (\d{4})$')
 prefix_date_reverse_re = re.compile(r'^(\d{4}) ([a-zA-Z]+[,.]?)$')
 
-try:
+if django.VERSION < (1, 8,):
     FIELD_BASE = with_metaclass(models.SubfieldBase, models.CharField)
-except AttributeError:
+else:
     FIELD_BASE = models.CharField
 
 

--- a/django_date_extensions/settings.py
+++ b/django_date_extensions/settings.py
@@ -31,3 +31,6 @@ DAY_MONTH_INPUT_FORMATS = getattr(settings, 'DATE_EXTENSIONS_DAY_MONTH_INPUT_FOR
     '%b %d', '%d %b',  # 'Oct 25', '25 Oct'
     '%B %d', '%d %B',  # 'October 25', '25 October'
 ))
+
+ALLOWED_PREFIX = [p.lower() for p in getattr(settings, 'DATE_EXTENSIONS_ALLOWED_PREFIX', [])]
+

--- a/django_date_extensions/settings.py
+++ b/django_date_extensions/settings.py
@@ -33,3 +33,6 @@ DAY_MONTH_INPUT_FORMATS = getattr(settings, 'DATE_EXTENSIONS_DAY_MONTH_INPUT_FOR
 ))
 
 ALLOWED_PREFIX = [p.lower() for p in getattr(settings, 'DATE_EXTENSIONS_ALLOWED_PREFIX', [])]
+
+# formats such as unknown, N/A (in-case sensitive)
+STRING_FORMATS = getattr(settings, 'DATE_EXTENSIONS_STRING_FORMATS', [])

--- a/django_date_extensions/settings.py
+++ b/django_date_extensions/settings.py
@@ -33,4 +33,3 @@ DAY_MONTH_INPUT_FORMATS = getattr(settings, 'DATE_EXTENSIONS_DAY_MONTH_INPUT_FOR
 ))
 
 ALLOWED_PREFIX = [p.lower() for p in getattr(settings, 'DATE_EXTENSIONS_ALLOWED_PREFIX', [])]
-

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -1,9 +1,27 @@
-from datetime import date
+from datetime import date, datetime
 import os
 import unittest
-from .fields import ApproximateDate
 
 os.environ['DJANGO_SETTINGS_MODULE'] = 'example.settings'
+
+from django.db import models
+from django import forms
+
+from . import settings
+from .fields import ApproximateDate, ApproximateDateField, ApproximateDateFormField
+
+settings.ALLOWED_PREFIX = ['about', 'about,', 'about.']
+
+
+class ApproxDateModel(models.Model):
+    start = ApproximateDateField()
+
+    def __unicode__(self):
+        return u'%s' % str(self.start)
+
+
+class ApproxDateForm(forms.Form):
+    start = ApproximateDateFormField()
 
 
 class PastAndFuture(unittest.TestCase):
@@ -34,6 +52,7 @@ class CompareDates(unittest.TestCase):
         y_future = ApproximateDate(year=2100)
         future = ApproximateDate(future=True)
         future_too = ApproximateDate(future=True)
+        prefix_dt = ApproximateDate(prefix='about', year=2010)
 
         # check that we can be compared to None, '' and u''
         for bad_val in ('', u'', None):
@@ -44,9 +63,11 @@ class CompareDates(unittest.TestCase):
         # sanity check
         self.assertTrue(y_past == y_past)
         self.assertTrue(y_future == y_future)
+        self.assertTrue(prefix_dt == prefix_dt)
 
         self.assertFalse(y_past != y_past)
         self.assertFalse(y_future != y_future)
+        self.assertFalse(prefix_dt != prefix_dt)
 
         self.assertTrue(y_past != y_future)
         self.assertTrue(y_future != y_past)
@@ -55,11 +76,15 @@ class CompareDates(unittest.TestCase):
         self.assertTrue(y_future >= y_past)
         self.assertFalse(y_past > y_future)
         self.assertFalse(y_past >= y_future)
+        self.assertFalse(prefix_dt > prefix_dt)
+        self.assertTrue(prefix_dt >= prefix_dt)
 
         self.assertTrue(y_past < y_future)
         self.assertTrue(y_past <= y_future)
         self.assertFalse(y_future < y_past)
         self.assertFalse(y_future <= y_past)
+        self.assertFalse(prefix_dt < prefix_dt)
+        self.assertTrue(prefix_dt <= prefix_dt)
 
         # Future dates are always greater
         self.assertTrue(y_past < future)
@@ -139,6 +164,78 @@ class Lengths(unittest.TestCase):
         for kwargs, length in self.known_lengths:
             approx = ApproximateDate(**kwargs)
             self.assertEqual(len(approx), length)
+
+
+class ApproxDateFiltering(unittest.TestCase):
+
+    def setUp(self):
+        for year in [2000, 2001, 2002, 2003, 2004]:
+            if year == 2004:
+                prefix = 'about'
+            else:
+                prefix = None
+            ApproxDateModel.objects.create(start=ApproximateDate(year=year, prefix=prefix))
+
+    def test_filtering_with_python_date(self):
+        qs = ApproxDateModel.objects.filter(start__gt=date.today())
+        # force evaluate queryset
+        list(qs)
+
+    def test_filtering_with_python_datetime(self):
+        qs = ApproxDateModel.objects.filter(start__gt=datetime.now())
+        # force evaluate queryset
+        list(qs)
+
+    def test_filtering_with_prefix_date(self):
+        self.assertEqual(ApproxDateModel.objects.filter(start=ApproximateDate(year=2004, prefix='about')).count(), 1)
+
+
+class PrefixDates(unittest.TestCase):
+    def test_valid(self):
+        ApproximateDate(year=2010, prefix='about')
+        ApproximateDate(year=2010, prefix='about.')
+        ApproximateDate(year=2010, prefix='about,')
+
+    def test_invalid(self):
+        self.assertRaises(ValueError, ApproximateDate, year=2015, prefix='what')
+        self.assertRaises(ValueError, ApproximateDate, year=2015, prefix='about?')
+
+    def test_stringification(self):
+        self.assertEqual(str(ApproximateDate(year=2010, prefix='about')), 'about 2010')
+        self.assertEqual(str(ApproximateDate(year=2010)), '2010')
+
+    def test_with_year_month_day(self):
+        self.assertRaises(ValueError, ApproximateDate, prefix='about', year=2015, month=12, day=1)
+
+    def test_with_year_month(self):
+        self.assertRaises(ValueError, ApproximateDate, prefix='about', year=2015, month=12)
+
+    def test_with_year(self):
+        self.assertRaises(ValueError, ApproximateDate, prefix='about', year=2015, month=12)
+
+    def test_stringification(self):
+        self.assertEqual(str(ApproximateDate(year=2010, prefix='about')), 'about 2010')
+        self.assertEqual(str(ApproximateDate(year=2010)), '2010')
+
+    def test_db(self):
+        ApproxDateModel.objects.create(start=ApproximateDate(year=2010, prefix='about'))
+        ApproxDateModel.objects.create(start=ApproximateDate(year=2010))
+        ApproxDateModel.objects.create(start=ApproximateDate(year=2010, month=12, day=1))
+
+    def test_date_with_prefix_form(self):
+        form = ApproxDateForm({'start': 'about 2015'})
+        self.assertTrue(form.is_valid())
+        form = ApproxDateForm({'start': '2015'})
+        self.assertTrue(form.is_valid())
+    
+    def test_ordering(self):
+        ApproxDateModel.objects.all().delete()
+        years = [2015, 2006, 2013, 2004, 2003, 1989]
+        for year in years:
+            ApproxDateModel.objects.create(start=ApproximateDate(year=year, prefix='about'))
+        self.assertEqual(sorted(years), [o.start.year for o in ApproxDateModel.objects.all().order_by('start')])
+        self.assertEqual(sorted(years, reverse=True), [o.start.year for o in ApproxDateModel.objects.all().order_by('-start')])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/django_date_extensions/tests.py
+++ b/django_date_extensions/tests.py
@@ -1,8 +1,5 @@
 from datetime import date, datetime
-import os
 import unittest
-
-os.environ['DJANGO_SETTINGS_MODULE'] = 'example.settings'
 
 from django.db import models
 from django import forms
@@ -187,7 +184,8 @@ class ApproxDateFiltering(unittest.TestCase):
         list(qs)
 
     def test_filtering_with_prefix_date(self):
-        self.assertEqual(ApproxDateModel.objects.filter(start=ApproximateDate(year=2004, prefix='about')).count(), 1)
+        qs = ApproxDateModel.objects.filter(start=ApproximateDate(year=2004, prefix='about'))
+        self.assertEqual(qs.count(), 1)
 
 
 class PrefixDates(unittest.TestCase):
@@ -213,10 +211,6 @@ class PrefixDates(unittest.TestCase):
     def test_with_year(self):
         self.assertRaises(ValueError, ApproximateDate, prefix='about', year=2015, month=12)
 
-    def test_stringification(self):
-        self.assertEqual(str(ApproximateDate(year=2010, prefix='about')), 'about 2010')
-        self.assertEqual(str(ApproximateDate(year=2010)), '2010')
-
     def test_db(self):
         ApproxDateModel.objects.create(start=ApproximateDate(year=2010, prefix='about'))
         ApproxDateModel.objects.create(start=ApproximateDate(year=2010))
@@ -227,14 +221,20 @@ class PrefixDates(unittest.TestCase):
         self.assertTrue(form.is_valid())
         form = ApproxDateForm({'start': '2015'})
         self.assertTrue(form.is_valid())
-    
+
     def test_ordering(self):
         ApproxDateModel.objects.all().delete()
         years = [2015, 2006, 2013, 2004, 2003, 1989]
         for year in years:
             ApproxDateModel.objects.create(start=ApproximateDate(year=year, prefix='about'))
-        self.assertEqual(sorted(years), [o.start.year for o in ApproxDateModel.objects.all().order_by('start')])
-        self.assertEqual(sorted(years, reverse=True), [o.start.year for o in ApproxDateModel.objects.all().order_by('-start')])
+        self.assertEqual(
+            sorted(years),
+            [o.start.year for o in ApproxDateModel.objects.all().order_by('start')]
+        )
+        self.assertEqual(
+            sorted(years, reverse=True),
+            [o.start.year for o in ApproxDateModel.objects.all().order_by('-start')]
+        )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR contains facility to define string only formats e.g. `n/a`, `unknown` via settings var `DATE_EXTENSIONS_STRING_FORMATS`

This PR is created on top of [prefix year dates PR](https://github.com/dracos/django-date-extensions/pull/13) so its better to merge that first.

Thanks!