### PR TITLE
Changed example files (setting.py, views.py, urls.py) so the project …

### DIFF
--- a/example/settings.py
+++ b/example/settings.py
@@ -1,7 +1,13 @@
+import os
 
 # Set DEBUG to true so that we don't need to provide a 500.html template
 # (django's debug on will be used instead).
 DEBUG = True
+# Build paths inside the project like this: os.path.join(BASE_DIR, ...)
+BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+print("base_dir=%s" % BASE_DIR)
+print("templates=%s" % os.path.join(BASE_DIR, 'example/templates'))
 
 SECRET_KEY = 'x9i*)8dp_i=r1o(p%0-g*^sz@_(631+_tjr=e-t04vj2!@l$8a'
 ROOT_URLCONF = 'example.urls'
@@ -15,3 +21,14 @@ DATABASES = {
         'NAME': 'example.sqlite3',
     }
 }
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'DIRS': [os.path.join(BASE_DIR, 'example/templates'), ],
+        'APP_DIRS': True,
+        'OPTIONS': {
+            # ... some options here ...
+        },
+    },
+]

--- a/example/urls.py
+++ b/example/urls.py
@@ -1,7 +1,6 @@
-from django.conf.urls import patterns
+from django.urls import path
 from .views import view
 
-urlpatterns = patterns(
-    '',
-    (r'^$', view),
-)
+urlpatterns = [
+    path('', view),
+]

--- a/example/views.py
+++ b/example/views.py
@@ -1,8 +1,8 @@
-from django.shortcuts import render_to_response
+from django.shortcuts import render
 from .forms import DatesForm
-
 
 def view(request):
     dates_form = DatesForm(request.GET or None)
     dates_form.is_valid()
-    return render_to_response('form.html', {'form': dates_form})
+    return render(request, 'form.html', {'form': dates_form})
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,7 @@
+Django==2.0.5
+django-debug-toolbar==1.9.1
+django-extensions==2.0.7
+pytz==2018.4
+six==1.11.0
+sqlparse==0.2.4
+typing==3.6.4


### PR DESCRIPTION
…will run with django 2.0.5 and python 3.4.3. 
I hope these changes are useful to someone who is using django > 2.0 and Python > 3.4. The requirements.txt file is a little bloated, as I use shell_plus and the django-debug-toolbar a lot for debugging. It could be reduced to just Django ==2.0.5.