### PR TITLE
replace _get_val_from_obj with value_from_object to solve "CommandError: Unable to serialize database"

### DIFF
--- a/django_date_extensions/fields.py
+++ b/django_date_extensions/fields.py
@@ -152,7 +152,7 @@ class ApproximateDateField(models.CharField):
         return value
 
     def value_to_string(self, obj):
-        value = self._get_val_from_obj(obj)
+        value = self.value_from_object(obj)
         return self.get_prep_value(value)
 
     def formfield(self, **kwargs):


### PR DESCRIPTION
I've replaced `_get_val_from_obj` with `value_from_object` in `ApproximateDateField.value_to_string`.

resolves #26